### PR TITLE
The actor name is wrong, it should be dependabot-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Automatically approve GitHub pull requests. Combine with the filter action to
 only auto-approve certain users. For example, to auto-approve
-[Dependabot][dependabot] pull requests, use `actor dependabot[bot]` as the args
+[Dependabot][dependabot] pull requests, use `actor dependabot-preview[bot]` as the args
 for the filter action.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Automatically approve GitHub pull requests. Combine with the filter action to
 only auto-approve certain users. For example, to auto-approve
-[Dependabot][dependabot] pull requests, use `actor dependabot-preview[bot]` as the args
+[Dependabot][dependabot] pull requests, use `["actor", "dependabot-preview[bot]", "dependabot[bot]"]` as the args
 for the filter action.
 
 <p align="center">


### PR DESCRIPTION
When using `actor dependabot[bot]` like in the doc, it gives:

> actor is "dependabot-preview[bot]", not any of "dependabot[bot]"

The actor name changed when Github bought dependabot.

:)