### PR TITLE
Merge after approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Name:** `hmarr/auto-approve-action`
 
-Automatically approve GitHub pull requests. The `GITHUB_TOKEN` secret must be provided as the `github-token` input for the action to work.
+Automatically approve GitHub pull requests. The `GITHUB_TOKEN` secret must be provided as the `github-token` input for the action to work. Optional `merge` input (boolean) allows to merge pull requests immediatly after approval.
 
 **Important:** use v2.0.0 or later, as v1 was designed for the initial GitHub Actions beta, and no longer works.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1452,18 +1452,21 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const token = core.getInput("github-token", { required: true });
+            const shouldMerge = core.getInput("merge");
             const { pull_request: pr } = github.context.payload;
             if (!pr) {
                 throw new Error("Event payload missing `pull_request`");
             }
             const client = new github.GitHub(token);
             core.debug(`Creating approving review for pull request #${pr.number}`);
-            yield client.pulls.createReview({
+            const params = {
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
-                pull_number: pr.number,
-                event: "APPROVE"
-            });
+                pull_number: pr.number
+            };
+            yield client.pulls.createReview(Object.assign(Object.assign({}, params), { event: "APPROVE" }));
+            if (shouldMerge)
+                yield client.pulls.merge(params);
             core.debug(`Approved pull request #${pr.number}`);
         }
         catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import * as github from "@actions/github";
 async function run() {
   try {
     const token = core.getInput("github-token", { required: true });
+    const shouldMerge = core.getInput("merge");
 
     const { pull_request: pr } = github.context.payload;
     if (!pr) {
@@ -12,12 +13,16 @@ async function run() {
 
     const client = new github.GitHub(token);
     core.debug(`Creating approving review for pull request #${pr.number}`);
-    await client.pulls.createReview({
+
+    const params = {
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
-      pull_number: pr.number,
-      event: "APPROVE"
-    });
+      pull_number: pr.number
+    };
+
+    await client.pulls.createReview({ ...params, event: "APPROVE" });
+    if (shouldMerge) await client.pulls.merge(params);
+
     core.debug(`Approved pull request #${pr.number}`);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Adds optional `merge` input to immediately merge the PR.

Protected branches should allow [`github-actions`](https://github.com/apps/github-actions) to push in order for this to work, but current version of [`@actions/github`](https://github.com/actions/toolkit/tree/master/packages/github) doesn't allow to automate it just yet. could be added later on.