### PR TITLE
Use default GITHUB_TOKEN by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,8 @@ branding:
 inputs:
   github-token:
     description: 'The GITHUB_TOKEN secret'
-    required: true
+    default: ${{ github.token }}
+    required: false
   pull-request-number:
     description: '(optional) The ID of a pull request to auto-approve. By default, this action tries to use the pull_request event payload.'
     required: false


### PR DESCRIPTION
This makes the `github-token` input non-mandatory, for cases where the default `GITHUB_TOKEN` is used.