### PR TITLE
Do not approve the same PR twice

### DIFF
--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -3,18 +3,21 @@ import { Context } from "@actions/github/lib/context";
 import nock from "nock";
 import { approve } from "./approve";
 
+const originalEnv = process.env;
+
 beforeEach(() => {
   jest.restoreAllMocks();
   jest.spyOn(core, "setFailed").mockImplementation(jest.fn());
   jest.spyOn(core, "info").mockImplementation(jest.fn());
   nock.disableNetConnect();
 
-  process.env["GITHUB_REPOSITORY"] = "hmarr/test";
+  process.env = { GITHUB_REPOSITORY: "hmarr/test" };
 });
 
 afterEach(() => {
   nock.cleanAll();
   nock.enableNetConnect();
+  process.env = originalEnv;
 });
 
 test("when a review is successfully created", async () => {

--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -7,8 +7,13 @@ beforeEach(() => {
   jest.restoreAllMocks();
   jest.spyOn(core, "setFailed").mockImplementation(jest.fn());
   jest.spyOn(core, "info").mockImplementation(jest.fn());
+  nock.disableNetConnect();
 
   process.env["GITHUB_REPOSITORY"] = "hmarr/test";
+});
+
+afterEach(() => {
+  nock.enableNetConnect();
 });
 
 test("when a review is successfully created", async () => {

--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -43,21 +43,21 @@ test("when a review is successfully created using pull-request-number", async ()
   nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
 
   nock("https://api.github.com")
-    .get("/repos/hmarr/test/pulls/101")
+    .get("/repos/hmarr/test/pulls/102")
     .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
 
   nock("https://api.github.com")
-    .get("/repos/hmarr/test/pulls/101/reviews")
+    .get("/repos/hmarr/test/pulls/102/reviews")
     .reply(200, []);
 
   nock("https://api.github.com")
-    .post("/repos/hmarr/test/pulls/101/reviews")
+    .post("/repos/hmarr/test/pulls/102/reviews")
     .reply(200, { id: 1 });
 
-  await approve("gh-tok", new Context(), 101);
+  await approve("gh-tok", new Context(), 102);
 
   expect(core.info).toHaveBeenCalledWith(
-    expect.stringContaining("Approved pull request #101")
+    expect.stringContaining("Approved pull request #102")
   );
 });
 

--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -12,6 +12,16 @@ beforeEach(() => {
 });
 
 test("when a review is successfully created", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, []);
+
   nock("https://api.github.com")
     .post("/repos/hmarr/test/pulls/101/reviews")
     .reply(200, { id: 1 });
@@ -24,6 +34,238 @@ test("when a review is successfully created", async () => {
 });
 
 test("when a review is successfully created using pull-request-number", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, []);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", new Context(), 101);
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
+test("when a review has already been approved by current user", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "hmarr" },
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "APPROVED",
+      },
+    ]);
+
+  await approve("gh-tok", ghContext());
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining(
+      "Current user already approved pull request #101, nothing to do"
+    )
+  );
+});
+
+test("when a review is pending", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "hmarr" },
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "PENDING",
+      },
+    ]);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", new Context(), 101);
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
+test("when a review is dismissed", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "hmarr" },
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "DISMISSED",
+      },
+    ]);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", new Context(), 101);
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
+test("when a review is not approved", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "hmarr" },
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "CHANGES_REQUESTED",
+      },
+    ]);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", new Context(), 101);
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
+test("when a review is commented", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "hmarr" },
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "COMMENTED",
+      },
+    ]);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", new Context(), 101);
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
+test("when an old commit has already been approved", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "hmarr" },
+        commit_id: "6a9ec7556f0a7fa5b49527a1eea4878b8a22d2e0",
+        state: "APPROVED",
+      },
+    ]);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", ghContext());
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
+test("when a review has already been approved by another user", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "some" },
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "APPROVED",
+      },
+    ]);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", new Context(), 101);
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
+test("when a review has already been approved by unknown user", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: null,
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "APPROVED",
+      },
+    ]);
+
   nock("https://api.github.com")
     .post("/repos/hmarr/test/pulls/101/reviews")
     .reply(200, { id: 1 });
@@ -45,7 +287,7 @@ test("without a pull request", async () => {
 
 test("when the token is invalid", async () => {
   nock("https://api.github.com")
-    .post("/repos/hmarr/test/pulls/101/reviews")
+    .get("/user")
     .reply(401, { message: "Bad credentials" });
 
   await approve("gh-tok", ghContext());
@@ -56,6 +298,16 @@ test("when the token is invalid", async () => {
 });
 
 test("when the token doesn't have write permissions", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, []);
+
   nock("https://api.github.com")
     .post("/repos/hmarr/test/pulls/101/reviews")
     .reply(403, { message: "Resource not accessible by integration" });
@@ -68,6 +320,16 @@ test("when the token doesn't have write permissions", async () => {
 });
 
 test("when a user tries to approve their own pull request", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, []);
+
   nock("https://api.github.com")
     .post("/repos/hmarr/test/pulls/101/reviews")
     .reply(422, { message: "Unprocessable Entity" });
@@ -79,7 +341,67 @@ test("when a user tries to approve their own pull request", async () => {
   );
 });
 
-test("when the token doesn't have access to the repository", async () => {
+test("when pull request does not exist", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(404, { message: "Not Found" });
+
+  await approve("gh-tok", ghContext());
+
+  expect(core.setFailed).toHaveBeenCalledWith(
+    expect.stringContaining("doesn't have access")
+  );
+});
+
+test("when the token doesn't have read access to the repository", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(404, { message: "Not Found" });
+
+  await approve("gh-tok", ghContext());
+
+  expect(core.setFailed).toHaveBeenCalledWith(
+    expect.stringContaining("doesn't have access")
+  );
+});
+
+test("when the token is read-only", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, []);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(403, { message: "Not Authorized" });
+
+  await approve("gh-tok", ghContext());
+
+  expect(core.setFailed).toHaveBeenCalledWith(
+    expect.stringContaining("are read-only")
+  );
+});
+
+test("when the token doesn't have write access to the repository", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, []);
+
   nock("https://api.github.com")
     .post("/repos/hmarr/test/pulls/101/reviews")
     .reply(404, { message: "Not Found" });

--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  nock.cleanAll();
   nock.enableNetConnect();
 });
 

--- a/src/approve.ts
+++ b/src/approve.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 import { RequestError } from "@octokit/request-error";
 import { Context } from "@actions/github/lib/context";
+import { userInfo } from "os";
 
 export async function approve(
   token: string,
@@ -22,8 +23,46 @@ export async function approve(
 
   const client = github.getOctokit(token);
 
-  core.info(`Creating approving review for pull request #${prNumber}`);
   try {
+    core.info(`Getting current user info`);
+    const { data: user } = await client.users.getAuthenticated();
+    core.info(`Current user is ${user.login}`);
+
+    core.info(`Getting pull request #${prNumber} info`);
+    const pull_request = await client.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: prNumber,
+    });
+    const commit = pull_request.data.head.sha;
+
+    core.info(`Commit SHA is ${commit}`);
+
+    core.info(
+      `Getting reviews for pull request #${prNumber} and commit ${commit}`
+    );
+    const reviews = await client.pulls.listReviews({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: prNumber,
+    });
+
+    for (const review of reviews.data) {
+      if (
+        review.user?.login == user.login &&
+        review.commit_id == commit &&
+        review.state == "APPROVED"
+      ) {
+        core.info(
+          `Current user already approved pull request #${prNumber}, nothing to do`
+        );
+        return;
+      }
+    }
+
+    core.info(
+      `Pull request #${prNumber} has not been approved yet, creating approving review`
+    );
     await client.pulls.createReview({
       owner: context.repo.owner,
       repo: context.repo.repo,
@@ -67,7 +106,6 @@ export async function approve(
       }
       return;
     }
-
     core.setFailed(error.message);
     return;
   }

--- a/src/approve.ts
+++ b/src/approve.ts
@@ -2,7 +2,6 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 import { RequestError } from "@octokit/request-error";
 import { Context } from "@actions/github/lib/context";
-import { userInfo } from "os";
 
 export async function approve(
   token: string,


### PR DESCRIPTION
Hi.

I've added this action to one of my workflows, and found that it can approve the same pull request multiple times:
https://github.com/MobileTeleSystems/mlflow-rest-client/pull/3
![image](https://user-images.githubusercontent.com/4661021/154841301-da55913c-d5fb-471d-9833-7f65bfe04072.png)

So I've added a check that pull request has already been approved by the current user.