### PR TITLE
Update actions runner node install to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: '(optional) The message of the pull request review.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
According to [this announcement by GitHub](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), running node v12 on Actions runners will soon be deprecated. 

This PR updates `action.yml` to specify node v16 in order to comply with GitHub's planned migration.