### PR TITLE
Add optional parameter, forceReview flag, fixes issue #206

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   review-message:
     description: '(optional) The message of the pull request review.'
     required: false
+  force-review:
+    description: '(optional) Re-approves the PR even if status is already approved. Used for cases when a PR requests for a re-review.'
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -302,6 +302,34 @@ test("when a review has already been approved by another user", async () => {
   );
 });
 
+test("when a review has already been approved by another user and forceReview is set to true", async () => {
+  nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101")
+    .reply(200, { head: { sha: "24c5451bbf1fb09caa3ac8024df4788aff4d4974" } });
+
+  nock("https://api.github.com")
+    .get("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, [
+      {
+        user: { login: "some" },
+        commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+        state: "APPROVED",
+      },
+    ]);
+
+  nock("https://api.github.com")
+    .post("/repos/hmarr/test/pulls/101/reviews")
+    .reply(200, { id: 1 });
+
+  await approve("gh-tok", new Context(), 101, undefined, true);
+
+  expect(core.info).toHaveBeenCalledWith(
+    expect.stringContaining("Approved pull request #101")
+  );
+});
+
 test("when a review has already been approved by unknown user", async () => {
   nock("https://api.github.com").get("/user").reply(200, { login: "hmarr" });
 

--- a/src/approve.ts
+++ b/src/approve.ts
@@ -8,10 +8,14 @@ export async function approve(
   token: string,
   context: Context,
   prNumber?: number,
-  reviewMessage?: string
+  reviewMessage?: string,
+  forceReview?: boolean,
 ) {
   if (!prNumber) {
     prNumber = context.payload.pull_request?.number;
+  }
+  if (forceReview == null) {
+    forceReview = false;
   }
 
   if (!prNumber) {
@@ -54,15 +58,21 @@ export async function approve(
         review.commit_id == commit &&
         review.state == "APPROVED"
       ) {
-        core.info(
-          `Current user already approved pull request #${prNumber}, nothing to do`
-        );
-        return;
+        if (forceReview) {
+          core.info(
+            `Current user already approved pull request #${prNumber}, but forceReview is set to true, so re-approving anyway`
+          )
+        } else {
+          core.info(
+            `Current user already approved pull request #${prNumber}, nothing to do`
+          );
+          return;
+        }
       }
     }
 
     core.info(
-      `Pull request #${prNumber} has not been approved yet, creating approving review`
+      `Creating approving review for pull request #${prNumber}`
     );
     await client.rest.pulls.createReview({
       owner: context.repo.owner,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -43,7 +43,8 @@ test("passes the review message to approve", async () => {
     "tok-xyz",
     expect.anything(),
     101,
-    "LGTM"
+    "LGTM",
+    expect.anything()
   );
 });
 
@@ -54,7 +55,8 @@ test("calls approve when no PR number is provided", async () => {
     "tok-xyz",
     expect.anything(),
     101,
-    undefined
+    undefined,
+    expect.anything()
   );
 });
 
@@ -65,7 +67,8 @@ test("calls approve when a valid PR number is provided", async () => {
     "tok-xyz",
     expect.anything(),
     456,
-    undefined
+    undefined,
+    expect.anything()
   );
 });
 
@@ -73,6 +76,31 @@ test("errors when an invalid PR number is provided", async () => {
   process.env["INPUT_PULL-REQUEST-NUMBER"] = "not a number";
   await run();
   expect(mockedApprove).not.toHaveBeenCalled();
+});
+
+test("calls approve when force-review is set to true", async () => {
+  process.env["INPUT_PULL-REQUEST-NUMBER"] = "456";
+  process.env["INPUT_FORCE-REVIEW"] = "true";
+  await run();
+  expect(mockedApprove).toHaveBeenCalledWith(
+    "tok-xyz",
+    expect.anything(),
+    456,
+    undefined,
+    true
+  );
+});
+
+test("calls approve when force-review is set to false", async () => {
+  process.env["INPUT_PULL-REQUEST-NUMBER"] = "456";
+  await run();
+  expect(mockedApprove).toHaveBeenCalledWith(
+    "tok-xyz",
+    expect.anything(),
+    456,
+    undefined,
+    false
+  );
 });
 
 function ghContext(): Context {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,8 @@ export async function run() {
       token,
       github.context,
       prNumber(),
-      reviewMessage || undefined
+      reviewMessage || undefined,
+      forceReview()
     );
   } catch (error) {
     if (error instanceof Error) {
@@ -37,6 +38,13 @@ function prNumber(): number {
     );
   }
   return github.context.payload.pull_request.number;
+}
+
+function forceReview(): boolean {
+  if (core.getInput("force-review") === undefined) {
+    return false;
+  }
+  return (/true/i).test(core.getInput("force-review"))
 }
 
 if (require.main === module) {


### PR DESCRIPTION
When `forceReview` is `true`, re-approves the pull request even if the current review state is already approved