### PR TITLE
Don't re-review when new commits are pushed

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10093,7 +10093,7 @@ function approve(token, context, prNumber, reviewMessage) {
             core.info(`Current user is ${login}`);
             const prHead = pr.head.sha;
             core.info(`Commit SHA is ${prHead}`);
-            const alreadyReviewed = reviews.some(({ user, commit_id, state }) => (user === null || user === void 0 ? void 0 : user.login) === login && commit_id == prHead && state === "APPROVED");
+            const alreadyReviewed = reviews.some(({ user, state }) => (user === null || user === void 0 ? void 0 : user.login) === login && state === "APPROVED");
             const outstandingReviewRequest = (_b = pr.requested_reviewers) === null || _b === void 0 ? void 0 : _b.some((reviewer) => reviewer.login == login);
             if (alreadyReviewed && !outstandingReviewRequest) {
                 core.info(`Current user already approved pull request #${prNumber}, nothing to do`);

--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -179,23 +179,6 @@ test("when a review is commented", async () => {
   expect(createReview.isDone()).toBe(true);
 });
 
-test("when an old commit has already been approved", async () => {
-  apiMocks.getUser();
-  apiMocks.getPull();
-  apiMocks.getReviews(200, [
-    {
-      user: { login: "hmarr" },
-      commit_id: "6a9ec7556f0a7fa5b49527a1eea4878b8a22d2e0",
-      state: "APPROVED",
-    },
-  ]);
-  const createReview = apiMocks.createReview();
-
-  await approve("gh-tok", ghContext());
-
-  expect(createReview.isDone()).toBe(true);
-});
-
 test("when a review has already been approved by another user", async () => {
   apiMocks.getUser();
   apiMocks.getPull();

--- a/src/approve.ts
+++ b/src/approve.ts
@@ -40,8 +40,7 @@ export async function approve(
     core.info(`Commit SHA is ${prHead}`);
 
     const alreadyReviewed = reviews.some(
-      ({ user, commit_id, state }) =>
-        user?.login === login && commit_id == prHead && state === "APPROVED"
+      ({ user, state }) => user?.login === login && state === "APPROVED"
     );
     const outstandingReviewRequest = pr.requested_reviewers?.some(
       (reviewer) => reviewer.login == login


### PR DESCRIPTION
It is possible to require re-reviews when new commits are pushed via branch protection rules, but when that setting is enabled existing reviews are transitioned to `DISMISSED`, so we should already handle that case with the `state === "APPROVED"` check.

Resolves #213