### PR TITLE
Only consider the latest review for a user

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10093,7 +10093,14 @@ function approve(token, context, prNumber, reviewMessage) {
             core.info(`Current user is ${login}`);
             const prHead = pr.head.sha;
             core.info(`Commit SHA is ${prHead}`);
-            const alreadyReviewed = reviews.some(({ user, state }) => (user === null || user === void 0 ? void 0 : user.login) === login && state === "APPROVED");
+            // Only the most recent review for a user counts towards the review state
+            const latestReviewForUser = [...reviews]
+                .reverse()
+                .find(({ user }) => (user === null || user === void 0 ? void 0 : user.login) === login);
+            const alreadyReviewed = (latestReviewForUser === null || latestReviewForUser === void 0 ? void 0 : latestReviewForUser.state) === "APPROVED";
+            // If there's an approved review from a user, but there's an outstanding review request,
+            // we need to create a new review. Review requests mean that existing "APPROVED" reviews
+            // don't count towards the mergeability of the PR.
             const outstandingReviewRequest = (_b = pr.requested_reviewers) === null || _b === void 0 ? void 0 : _b.some((reviewer) => reviewer.login == login);
             if (alreadyReviewed && !outstandingReviewRequest) {
                 core.info(`Current user already approved pull request #${prNumber}, nothing to do`);

--- a/src/approve.test.ts
+++ b/src/approve.test.ts
@@ -145,6 +145,28 @@ test("when a review is dismissed", async () => {
   expect(createReview.isDone()).toBe(true);
 });
 
+test("when a review is dismissed, but an earlier review is approved", async () => {
+  apiMocks.getUser();
+  apiMocks.getPull();
+  apiMocks.getReviews(200, [
+    {
+      user: { login: "hmarr" },
+      commit_id: "6a9ec7556f0a7fa5b49527a1eea4878b8a22d2e0",
+      state: "APPROVED",
+    },
+    {
+      user: { login: "hmarr" },
+      commit_id: "24c5451bbf1fb09caa3ac8024df4788aff4d4974",
+      state: "DISMISSED",
+    },
+  ]);
+  const createReview = apiMocks.createReview();
+
+  await approve("gh-tok", new Context(), 101);
+
+  expect(createReview.isDone()).toBe(true);
+});
+
 test("when a review is not approved", async () => {
   apiMocks.getUser();
   apiMocks.getPull();


### PR DESCRIPTION
It's possible to have `APPROVED` reviews from a user, with subsequent `DISMISSED` reviews. In this case, only the latest review is counts towards the PR's merge state.

#214 caused these old `APPROVED` reviews to prevent re-review from happening (reported by @pfuhrmann in https://github.com/hmarr/auto-approve-action/issues/213#issuecomment-1470180022).

This change only considers the _latest_ review for the approving user, meaning that old `APPROVED` reviews will no longer be considered when deciding whether to re-review.